### PR TITLE
new s3 configuration source

### DIFF
--- a/core/src/main/scala/com/gu/cm/S3ConfigurationSource.scala
+++ b/core/src/main/scala/com/gu/cm/S3ConfigurationSource.scala
@@ -30,12 +30,12 @@ class S3ConfigurationSource(s3: AmazonS3Client, identity: Identity, bucket: Stri
 
 object S3ConfigurationSource {
   def apply(identity: Identity, bucket: String, credentials: AWSCredentialsProvider = new DefaultAWSCredentialsProviderChain()): S3ConfigurationSource = {
-    val dynamoDb = {
+    val s3 = {
       val client = new AmazonS3Client(credentials)
       client.setRegion(RegionUtils.getRegion(identity.region))
       client.setEndpoint(RegionUtils.getRegion(identity.region).getServiceEndpoint(S3))
       client
     }
-    new S3ConfigurationSource(dynamoDb, identity, bucket)
+    new S3ConfigurationSource(s3, identity, bucket)
   }
 }

--- a/core/src/main/scala/com/gu/cm/S3ConfigurationSource.scala
+++ b/core/src/main/scala/com/gu/cm/S3ConfigurationSource.scala
@@ -1,0 +1,41 @@
+package com.gu.cm
+
+import com.amazonaws.auth.{AWSCredentialsProvider, DefaultAWSCredentialsProviderChain}
+import com.amazonaws.regions.RegionUtils
+import com.amazonaws.regions.ServiceAbbreviations.S3
+import com.amazonaws.services.s3.AmazonS3Client
+import com.amazonaws.services.s3.model.GetObjectRequest
+import com.typesafe.config.{Config, ConfigFactory}
+
+import scala.util.{Failure, Success, Try}
+
+class S3ConfigurationSource(s3: AmazonS3Client, identity: Identity, bucket: String) extends ConfigurationSource {
+
+  override def load: Config = {
+    val configPath = s"config/${identity.region}-${identity.stack}.conf"
+    val request = new GetObjectRequest(bucket, configPath)
+    val config = for {
+      result <- Try(s3.getObject(request))
+      item <- Try(scala.io.Source.fromInputStream(result.getObjectContent, "UTF-8").mkString)
+    } yield {
+      ConfigFactory.parseString(item)
+    }
+
+    config match {
+      case Success(theConfig) => theConfig
+      case Failure(theFailure) => ConfigFactory.empty(s"no s3 config (or failed to load) for bucket=$bucket path=$configPath, exception=[$theFailure]")
+    }
+  }
+}
+
+object S3ConfigurationSource {
+  def apply(identity: Identity, bucket: String, credentials: AWSCredentialsProvider = new DefaultAWSCredentialsProviderChain()): S3ConfigurationSource = {
+    val dynamoDb = {
+      val client = new AmazonS3Client(credentials)
+      client.setRegion(RegionUtils.getRegion(identity.region))
+      client.setEndpoint(RegionUtils.getRegion(identity.region).getServiceEndpoint(S3))
+      client
+    }
+    new S3ConfigurationSource(dynamoDb, identity, bucket)
+  }
+}

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.1-SNAPSHOT"
+version in ThisBuild := "1.2.1"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.1"
+version in ThisBuild := "1.2.2-SNAPSHOT"


### PR DESCRIPTION
added a new s3 configuration source, it will look in the specificed bucket for a directory `config`, and it will use the region and stack from the identity as the name of the file.

not sure if we should let the caller decide whcih parts of the identity are used in the file name (and which parts are nested within the file)?
