### PR TITLE
Add s3 versioning parameter

### DIFF
--- a/core/src/main/scala/com/gu/cm/S3ConfigurationSource.scala
+++ b/core/src/main/scala/com/gu/cm/S3ConfigurationSource.scala
@@ -12,7 +12,7 @@ import scala.util.{Failure, Success, Try}
 class S3ConfigurationSource(s3: AmazonS3Client, identity: Identity, bucket: String, version: Option[Int]) extends ConfigurationSource {
 
   override def load: Config = {
-    val fileVersion = ".v" + version.getOrElse("")
+    val fileVersion = version.map(".v" + _).getOrElse("")
     val configPath = s"config/${identity.region}-${identity.stack}$fileVersion.conf"
     val request = new GetObjectRequest(bucket, configPath)
     val config = for {

--- a/core/src/main/scala/com/gu/cm/S3ConfigurationSource.scala
+++ b/core/src/main/scala/com/gu/cm/S3ConfigurationSource.scala
@@ -12,7 +12,7 @@ import scala.util.{Failure, Success, Try}
 class S3ConfigurationSource(s3: AmazonS3Client, identity: Identity, bucket: String, version: Option[Int]) extends ConfigurationSource {
 
   override def load: Config = {
-    val fileVersion = "." + version.getOrElse("")
+    val fileVersion = ".v" + version.getOrElse("")
     val configPath = s"config/${identity.region}-${identity.stack}$fileVersion.conf"
     val request = new GetObjectRequest(bucket, configPath)
     val config = for {

--- a/core/src/test/scala/com/gu/cm/s3ConfigurationSourceSpec.scala
+++ b/core/src/test/scala/com/gu/cm/s3ConfigurationSourceSpec.scala
@@ -1,27 +1,11 @@
 package com.gu.cm
 
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
 import com.amazonaws.regions.RegionUtils
 import com.amazonaws.regions.ServiceAbbreviations._
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
-import com.amazonaws.services.dynamodbv2.document.DynamoDB
-import com.amazonaws.services.dynamodbv2.document.Item
-import com.amazonaws.services.dynamodbv2.document.{Item, DynamoDB}
-import com.amazonaws.services.dynamodbv2.model.AttributeDefinition
-import com.amazonaws.services.dynamodbv2.model.CreateTableRequest
-import com.amazonaws.services.dynamodbv2.model.KeySchemaElement
-import com.amazonaws.services.dynamodbv2.model.KeyType
-import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput
-import com.amazonaws.services.dynamodbv2.model._
 import com.amazonaws.services.s3.AmazonS3Client
-import com.typesafe.config.ConfigFactory
-import com.typesafe.config.ConfigFactory
 import org.specs2.mutable.Specification
 import org.specs2.specification.Scope
-
-import scala.collection.JavaConverters._
 
 class s3ConfigurationSourceSpec extends Specification {
   "a s3 configuration Source" should {

--- a/core/src/test/scala/com/gu/cm/s3ConfigurationSourceSpec.scala
+++ b/core/src/test/scala/com/gu/cm/s3ConfigurationSourceSpec.scala
@@ -1,8 +1,59 @@
 package com.gu.cm
 
-/**
-  * Created by dkendrick on 31/08/2016.
-  */
-class s3ConfigurationSourceSpec {
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+import com.amazonaws.regions.RegionUtils
+import com.amazonaws.regions.ServiceAbbreviations._
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient
+import com.amazonaws.services.dynamodbv2.document.DynamoDB
+import com.amazonaws.services.dynamodbv2.document.Item
+import com.amazonaws.services.dynamodbv2.document.{Item, DynamoDB}
+import com.amazonaws.services.dynamodbv2.model.AttributeDefinition
+import com.amazonaws.services.dynamodbv2.model.CreateTableRequest
+import com.amazonaws.services.dynamodbv2.model.KeySchemaElement
+import com.amazonaws.services.dynamodbv2.model.KeyType
+import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput
+import com.amazonaws.services.dynamodbv2.model._
+import com.amazonaws.services.s3.AmazonS3Client
+import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigFactory
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
 
+import scala.collection.JavaConverters._
+
+class s3ConfigurationSourceSpec extends Specification {
+  "a s3 configuration Source" should {
+    "look for a versioned file if a version is present" in new s3Scope {
+      val version = 2
+      val filePath = s3ConfigurationSource.versionedFilePath(identity, Some(version))
+      filePath shouldEqual "config/eu-west-1-test-stack.v2.conf"
+    }
+
+    "look for a non versioned file if a version is not present" in new s3Scope {
+      val filePath = s3ConfigurationSource.versionedFilePath(identity, None)
+      filePath shouldEqual "config/eu-west-1-test-stack.conf"
+    }
+  }
+
+  trait s3Scope extends Scope {
+
+    val identity = AwsApplication(
+      stack = "test-stack",
+      app = "configuration-magic",
+      stage = "test",
+      region = "eu-west-1"
+    )
+
+    val s3 = {
+      val client = new AmazonS3Client(new DefaultAWSCredentialsProviderChain())
+      client.setRegion(RegionUtils.getRegion(identity.region))
+      client.setEndpoint(RegionUtils.getRegion(identity.region).getServiceEndpoint(S3))
+      client
+    }
+
+    val s3ConfigurationSource = new S3ConfigurationSource(s3, identity, "frontend", Some(1))
+
+  }
 }

--- a/core/src/test/scala/com/gu/cm/s3ConfigurationSourceSpec.scala
+++ b/core/src/test/scala/com/gu/cm/s3ConfigurationSourceSpec.scala
@@ -1,0 +1,8 @@
+package com.gu.cm
+
+/**
+  * Created by dkendrick on 31/08/2016.
+  */
+class s3ConfigurationSourceSpec {
+
+}


### PR DESCRIPTION
This PR allows users of this library to optionally version their config files in s3. 
If a version in passed in the library will look for a versioned config file. 

Requesting version `2` for `frontend` we will look in:
`config/eu-west-1-frontend.v2.conf`

if no version in passed it will continue to look in:
`config/eu-west-1-frontend.conf`

This allows developers to test changes via s3 without 
- having to make changes to config locally
- having to overwrite the single master copy of the config file with potentially breaking changes

@alexduf 
