### PR TITLE
Add support for AWS Systems Manager Parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,23 @@ Thus your EC2 instance profile will need the following permissions:
 }
 ```
 
+#### For AWS Systems Manager Parameters
+
+**Note**: Requires `kms:Decrypt` permissions on a KMS key (`ConfigKmsKeyId`):
+
+```
+{
+    "Effect": "Allow",
+    "Action": "ssm:GetParametersByPath",
+    "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${ProjectName}/${EnvironmentName}
+    "Resource": { "Fn::Sub": "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${Stack}/${Stage}/${App}" }
+}, {
+    "Effect": "Allow",
+    "Action": "kms:Decrypt",
+    Resource: { "Fn::Sub": "arn:aws:kms:${AWS::Region}:*:key/${ConfigKmsKeyId}" }
+}
+```
+
 ## configuration-magic-play2-6
 
 This module aim to simplify the usage of configuration magic for play 2.6 and above.

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,8 @@ lazy val core = project
       "com.typesafe" % "config" % "1.3.0",
       "org.specs2" %% "specs2-core" % "3.9.5" % "test",
       "com.amazonaws" % "aws-java-sdk-dynamodb" % AwsSdkVersion,
-      "com.amazonaws" % "aws-java-sdk-ec2" % AwsSdkVersion
+      "com.amazonaws" % "aws-java-sdk-ec2" % AwsSdkVersion,
+      "com.amazonaws" % "aws-java-sdk-ssm" % "1.11.249"
     ),
     test in Test <<= (test in Test).dependsOn(DynamoDBLocal.Keys.startDynamoDBLocal),
     testOnly in Test <<= (testOnly in Test).dependsOn(DynamoDBLocal.Keys.startDynamoDBLocal),

--- a/core/src/main/scala/com/gu/cm/SystemsManagerParametersConfigurationSource.scala
+++ b/core/src/main/scala/com/gu/cm/SystemsManagerParametersConfigurationSource.scala
@@ -1,0 +1,71 @@
+package com.gu.cm
+
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain
+import com.amazonaws.regions.Regions
+import com.amazonaws.services.simplesystemsmanagement.model.GetParametersByPathRequest
+import com.amazonaws.services.simplesystemsmanagement.model.Parameter
+import com.amazonaws.services.simplesystemsmanagement.{AWSSimpleSystemsManagement, AWSSimpleSystemsManagementClientBuilder}
+import com.typesafe.config.{Config, ConfigFactory}
+
+import scala.collection.JavaConverters._
+import scala.util.{Failure, Success, Try}
+
+
+class SystemsManagerParametersConfigurationSource(systemsManager: AWSSimpleSystemsManagement, identity: Identity) extends ConfigurationSource {
+
+  val path = s"/${identity.stack}/${identity.stage}/${identity.app}"
+  val pathWithTrailingSlash = s"$path/"
+
+  final case class ParametersPage(parameters: Seq[Parameter], nextToken: Option[String])
+  final object ParametersPage {
+    val first = ParametersPage(Seq(), None)
+  }
+
+  def getAllParametersByPath(path: String): Map[String, _] = {
+    def getAllParametersByPathPaginated(path: String, currentParametersPage: ParametersPage): ParametersPage = {
+      val result = systemsManager.getParametersByPath(new GetParametersByPathRequest()
+        .withPath(path)
+        .withMaxResults(10)
+        .withWithDecryption(true)
+        .withNextToken(currentParametersPage.nextToken.orNull)
+      )
+      val parametersPage = ParametersPage(
+        parameters = result.getParameters.asScala ++ currentParametersPage.parameters,
+        nextToken = Option(result.getNextToken)
+      )
+      if (parametersPage.nextToken.isDefined) {
+        getAllParametersByPathPaginated(path, parametersPage)
+      } else {
+        parametersPage
+      }
+    }
+
+    val parametersPage = getAllParametersByPathPaginated(path, ParametersPage.first)
+
+    parametersPage.parameters.map(p => (p.getName.replace(pathWithTrailingSlash, ""), p.getValue)).toMap
+  }
+
+  override def load: Config = {
+    val config = for {
+      parameters <- Try(getAllParametersByPath(path))
+    } yield {
+      ConfigFactory.parseMap(parameters.asJava, s"Systems Manager Parameters $path [App=${identity.app}, Stage=${identity.stage}]")
+    }
+
+    config match {
+      case Success(theConfig) => theConfig
+      case Failure(theFailure) => ConfigFactory.empty(s"no Systems Manager Parameters (or failed to load) for $path [App=${identity.app}, Stage=${identity.stage}], exception=[$theFailure]")
+    }
+  }
+}
+
+object SystemsManagerParametersConfigurationSource {
+  def apply(identity: Identity): SystemsManagerParametersConfigurationSource = {
+    val systemsManager: AWSSimpleSystemsManagement = AWSSimpleSystemsManagementClientBuilder.standard()
+      .withCredentials(new DefaultAWSCredentialsProviderChain())
+      .withRegion(Regions.fromName(identity.region))
+      .build()
+
+    new SystemsManagerParametersConfigurationSource(systemsManager, identity)
+  }
+}

--- a/core/src/test/scala/com/gu/cm/SystemsManagerParametersConfigurationSourceSpec.scala
+++ b/core/src/test/scala/com/gu/cm/SystemsManagerParametersConfigurationSourceSpec.scala
@@ -1,0 +1,103 @@
+package com.gu.cm
+
+
+import com.amazonaws.services.simplesystemsmanagement.AWSSimpleSystemsManagementClient
+import com.amazonaws.services.simplesystemsmanagement.model.{GetParametersByPathRequest, GetParametersByPathResult, Parameter}
+import org.specs2.mutable.Specification
+import org.specs2.specification.Scope
+
+import scala.collection.JavaConverters._
+import scala.collection.immutable.ListMap
+
+
+class SystemsManagerParametersConfigurationSourceSpec extends Specification {
+  "a Systems Manager Parameters configuration Source" should {
+    "load a config from Systems Manager Parameters" in new SystemsManagerParametersScope(Map(
+      "/test-stack/prod/configuration-magic/bar" -> "evenbiggersecret",
+      "/test-stack/prod/configuration-magic/foo.a" -> "142",
+      "/test-stack/test/configuration-magic/bar" -> "secret",
+      "/test-stack/test/configuration-magic/foo.a" -> "42"
+    )) {
+      val conf = systemsManagerParametersConfigurationSource.load
+
+      conf.entrySet().size shouldEqual 2
+
+      conf.getString("bar") shouldEqual "secret"
+      conf.getInt("foo.a") shouldEqual 42
+    }
+
+    "load a config from Systems Manager Parameters with more than 10 parameters" in new SystemsManagerParametersScope(Map(
+      "/test-stack/prod/configuration-magic/foo.1" -> "60",
+      "/test-stack/prod/configuration-magic/foo.2" -> "61",
+      "/test-stack/test/configuration-magic/foo.1" -> "42",
+      "/test-stack/test/configuration-magic/foo.2" -> "43",
+      "/test-stack/test/configuration-magic/foo.3" -> "44",
+      "/test-stack/test/configuration-magic/foo.4" -> "45",
+      "/test-stack/test/configuration-magic/foo.5" -> "46",
+      "/test-stack/test/configuration-magic/foo.6" -> "47",
+      "/test-stack/test/configuration-magic/foo.7" -> "48",
+      "/test-stack/test/configuration-magic/foo.8" -> "49",
+      "/test-stack/test/configuration-magic/foo.9" -> "50",
+      "/test-stack/test/configuration-magic/foo.10" -> "51",
+      "/test-stack/test/configuration-magic/foo.11" -> "52",
+      "/test-stack/test/configuration-magic/foo.12" -> "53",
+      "/test-stack/test/configuration-magic/foo.13" -> "54",
+      "/test-stack/test/configuration-magic/foo.14" -> "55",
+      "/test-stack/test/configuration-magic/foo.15" -> "56"
+    )) {
+      val conf = systemsManagerParametersConfigurationSource.load
+
+      conf.entrySet().size shouldEqual 15
+
+      conf.getInt("foo.1") shouldEqual 42
+      conf.getInt("foo.2") shouldEqual 43
+      conf.getInt("foo.3") shouldEqual 44
+      conf.getInt("foo.4") shouldEqual 45
+      conf.getInt("foo.5") shouldEqual 46
+      conf.getInt("foo.6") shouldEqual 47
+      conf.getInt("foo.7") shouldEqual 48
+      conf.getInt("foo.8") shouldEqual 49
+      conf.getInt("foo.9") shouldEqual 50
+      conf.getInt("foo.10") shouldEqual 51
+      conf.getInt("foo.11") shouldEqual 52
+      conf.getInt("foo.12") shouldEqual 53
+      conf.getInt("foo.13") shouldEqual 54
+      conf.getInt("foo.14") shouldEqual 55
+      conf.getInt("foo.15") shouldEqual 56
+    }
+  }
+
+  class SystemsManagerParametersScope(val values: Map[String, String]) extends Scope {
+
+    val identity = AwsApplication(
+      stack = "test-stack",
+      app = "configuration-magic",
+      stage = "test",
+      region = "eu-west-1"
+    )
+
+    class SimpleSystemsManagementParameterStore(values: Map[String, String]) extends AWSSimpleSystemsManagementClient {
+
+      override def getParametersByPath(request: GetParametersByPathRequest): GetParametersByPathResult = {
+        val offset = Option(request.getNextToken).map(Integer.valueOf).getOrElse(Integer.valueOf(0))
+
+        val sortedParameters = ListMap(values.filter(v => v._1.startsWith(request.getPath)).toSeq.sortBy(_._1):_*)
+        val parameters = sortedParameters.slice(offset, offset + request.getMaxResults).map(v => new Parameter().withName(v._1).withValue(v._2))
+
+        val response = new GetParametersByPathResult().withParameters(parameters.asJavaCollection)
+
+        if (sortedParameters.size > offset + request.getMaxResults) {
+          response.withNextToken((request.getMaxResults + offset).toString)
+        } else {
+          response.withNextToken(null)
+        }
+
+        response
+      }
+    }
+
+    val systemsManager = new SimpleSystemsManagementParameterStore(values)
+
+    val systemsManagerParametersConfigurationSource = new SystemsManagerParametersConfigurationSource(systemsManager, identity)
+  }
+}


### PR DESCRIPTION
[AWS Systems Manager Parameters](http://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-working.html) now supports KMS encryption and is a great place for storing configuration.

This pull request adds a new `ConfigurationSource` that uses [AWS Systems Manager Parameters](http://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-working.html) as its back-end.

The new API for SSM was added in more recent versions of the AWS SDK, which is why `aws-java-sdk-ssm` is at a higher version separate from the existing dependencies. I first went down the route of bumping everything to `1.11.249`, but there were quite a few deprecation warnings for things being used by the S3 and DynamoDB implementations.